### PR TITLE
Support links between module names in imports and the files defining the module.

### DIFF
--- a/kythe/typescript/testdata/index_importer.ts
+++ b/kythe/typescript/testdata/index_importer.ts
@@ -1,0 +1,2 @@
+//- @"'./index_module'" ref/imports ModRef=VName("module", _, _, "testdata/index_module/index", _)
+import {foo} from './index_module';

--- a/kythe/typescript/testdata/index_module/index.ts
+++ b/kythe/typescript/testdata/index_module/index.ts
@@ -1,0 +1,2 @@
+//- @"export" defines/binding Alt=VName("module", _, _, "testdata/index_module/index", _)
+export const foo = 3

--- a/kythe/typescript/testdata/module.ts
+++ b/kythe/typescript/testdata/module.ts
@@ -3,6 +3,7 @@
 // without an extension).
 //- Mod=vname("module", _, _, "testdata/module", _).node/kind record
 
+//- @"export" defines/binding Mod
 export var value = 3;
 
 export type MyType = string;

--- a/kythe/typescript/testdata/reexport_importer.ts
+++ b/kythe/typescript/testdata/reexport_importer.ts
@@ -1,0 +1,2 @@
+//- @"'./reexporter'" ref/imports Rexp=VName("module", _, _, "testdata/reexporter", _)
+import {value} from './reexporter';

--- a/kythe/typescript/testdata/reexporter.ts
+++ b/kythe/typescript/testdata/reexporter.ts
@@ -1,0 +1,2 @@
+//- @"export" defines/binding Rexp=VName("module", _, _, "testdata/reexporter", _)
+export {value} from './module';


### PR DESCRIPTION
The metadata was already created on the module names in the import statements, but we didn't have the corresponding metadata in the file that defines the module.  To support, 2 way linking, the metadata is anchored on the first export keyword in a module.  The tests added cover exports on variable statements as well as stand alone exports, as well as the case when the module is named after a directory, but defined by an index.ts file.